### PR TITLE
[KNOX-176]: K8S Default Deployment Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This GitHub Action encapsulates all of the build and deploy steps required to de
 
 ```yaml
 - name: Build and Deploy Kubernetes
-  uses: dmsi-io/gha-go-deploy@v1
+  uses: dmsi-io/gha-go-deploy@v1.1
   with: 
     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Sometimes when trying to debug a k8s deployment that refuses to deploy correctly
 
 ```yaml
   with:
-    skip_deploy_status: 'true'
+    skip_deploy_status: true
 ```
 
 #### Go Version
@@ -70,7 +70,7 @@ By default, this GitHub Action will download and save a cache of the dependencie
 
 ```yaml
   with:
-    skip_cache: 'true'
+    skip_cache: true
 ```
 
 #### Skip Dependency Install
@@ -81,7 +81,7 @@ By default, this GitHub Action will download and verify dependencies before test
 
 ```yaml
   with:
-    skip_install: 'true'
+    skip_install: true
 ```
 
 #### Skip Testing
@@ -92,7 +92,7 @@ By default, this GitHub Action will run all tests before building. This can be s
 
 ```yaml
   with:
-    skip_testing: 'true'
+    skip_testing: true
 ```
 
 #### Test Flags

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This GitHub Action encapsulates all of the build and deploy steps required to de
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}
     GCP_ZONE: ${{ secrets.GCP_ZONE }}
     GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+    GHA_ACCESS_USER: ${{ secrets.GHA_ACCESS_USER }}
+    GHA_ACCESS_TOKEN: ${{ secrets.GHA_ACCESS_TOKEN }}
     TLD: ${{ secrets.TOP_LEVEL_DOMAIN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ This GitHub Action encapsulates all of the build and deploy steps required to de
     TLD: ${{ secrets.TOP_LEVEL_DOMAIN }}
 ```
 
-As of v1 of this GitHub Action, it is assumed that all required Kubernetes config files exist within the Go repository at the default directory and filename as follows:
+As of v1.1 of this GitHub Action, there will be provided default Kubernetes configuration yaml files. These are the standard for our Go Middleware Services. If a custom configuration is required, those can be supplied in the repository in question under the default folder structure as follows:
 
 ![Kubernetes Directory](/assets/k8s_directory.png)
+
+> Only supply the k8s yaml file that requires customization, all others will be copied in from this GitHub Action.
 
 Additionally, the Dockerfile must also be located at the head of the repository.
 

--- a/action.yaml
+++ b/action.yaml
@@ -78,6 +78,8 @@ runs:
         TLD: ${{ inputs.TLD }}
         GCP_PROJECT_ID: ${{ inputs.GCP_PROJECT_ID }}
 
+    ###### Setup and build Go executable ######
+
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
@@ -120,6 +122,26 @@ runs:
         CGO_ENABLED: '0'
         GOOS: linux
       shell: bash
+
+    ###### Check and setup Kubernetes configs
+
+    - name: Check k8s folder existence
+      id: k8s_exists
+      uses: andstor/file-existence-action@v1.0.1
+      with:
+        files: "k8s"
+
+    - name: Create k8s directory
+      if: steps.k8s_exists.outputs.files_exists != 'true'
+      run: mkdir k8s
+      shell: bash
+
+    - name: Copy missing k8s config files
+      run: |
+        cp -inv ${{ github.action_path }}/k8s/* k8s
+      shell: bash
+
+    ###### Deploy Kubernetes ######
 
     - name: Deploy Kubernetes
       uses: dmsi-io/gha-k8s-deploy@v1

--- a/action.yaml
+++ b/action.yaml
@@ -137,8 +137,7 @@ runs:
       shell: bash
 
     - name: Copy missing k8s config files
-      run: |
-        cp -inv ${{ github.action_path }}/k8s/* k8s
+      run: cp -inv ${{ github.action_path }}/k8s/* k8s
       shell: bash
 
     ###### Deploy Kubernetes ######

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $SERVICE_NAME
+  labels:
+    app: $SERVICE_NAME
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: $SERVICE_NAME
+  template:
+    metadata:
+      name: $SERVICE_NAME
+      labels:
+        app: $SERVICE_NAME
+        tier: web
+    spec:
+      containers:
+        - name: $SERVICE_NAME
+          image: $BUILD_IMAGE
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: redis-env
+          ports:
+            - name: web
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 3

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SERVICE_NAME
+  labels:
+    app: $SERVICE_NAME
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: $SERVICE_NAME
+    tier: web


### PR DESCRIPTION
The purpose of this change is to allow for default yamls to be pulled in when not supplied by the acting repository. Each of the provided defaults will not be added if they already exist within the acting repo.

PR of this new version: https://github.com/dmsi-io/viewers-api/pull/2/files
Example Action in use: https://github.com/dmsi-io/viewers-api/runs/4459386323?check_suite_focus=true

