### PR TITLE
GraphQL Schema Reset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine
+
+LABEL DMSi Software
+
+ADD main main
+
+EXPOSE 8080
+
+CMD ["/main"]

--- a/README.md
+++ b/README.md
@@ -172,3 +172,14 @@ Sometimes it is helpful to view gcloud information to help debug. Supplying this
 with:
   print_gcloud_info: true
 ```
+
+#### Print Go Environment
+
+Sometimes it is helpful to view the Go environment to help debug. Supplying this flag will print `go env` to the console.
+
+- Default: `false`
+
+```yaml
+with:
+  print_go_env: true
+```

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ with:
 
 By default, this GitHub Action will run all tests before building. The following input field allows additional flags to be added to the CLI `test` command.
 
-- Default: `false`
-
 ```yaml
 with:
   test_flags: '-tags mock' # example, can be any available CLI flags
@@ -109,8 +107,6 @@ with:
 #### Build Flags
 
 The following input field allows additional flags to be added to the CLI `build` command.
-
-- Default: `false`
 
 ```yaml
 with:
@@ -125,7 +121,7 @@ Our middleware is powered by a central graphql-api that will pull all available 
 
 ```yaml
 with:
-  skip_reset_schema: 'true'
+  skip_reset_schema: true
 ```
 
 #### Endpoint Ping
@@ -147,7 +143,7 @@ Sometimes it is helpful to view the environment variables set to help debug. Sup
 
 ```yaml
 with:
-  print_environemnt: 'true'
+  print_environemnt: true
 ```
 
 #### Print GCloud Info
@@ -158,5 +154,5 @@ Sometimes it is helpful to view gcloud information to help debug. Supplying this
 
 ```yaml
 with:
-  print_gcloud_info: 'true'
+  print_gcloud_info: true
 ```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Sometimes it is helpful to view the environment variables set to help debug. Sup
 
 ```yaml
 with:
-  print_environemnt: true
+  print_environment: true
 ```
 
 #### Print GCloud Info

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This GitHub Action encapsulates all of the build and deploy steps required to de
 
 ```yaml
 - name: Build and Deploy Kubernetes
-  uses: dmsi-io/gha-go-deploy@v1.1
+  uses: dmsi-io/gha-go-deploy@v1.2
   with:
     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}
@@ -30,6 +30,22 @@ As of v1.1 of this GitHub Action, there will be provided default Kubernetes conf
 > Only supply the k8s yaml file that requires customization, all others will be copied in from this GitHub Action.
 
 Additionally, the Dockerfile must also be located at the head of the repository.
+
+### Outputs
+
+#### URL
+
+Since this action deploys to a branch specific namespace, this action will output a URL to the namespace.
+
+```yaml
+- name: Build and Deploy Kubernetes
+  uses: dmsi-io/gha-go-deploy@v1.2
+  id: deploy
+  with: ...
+
+- name: Print URL
+  run: echo ${{ steps.deploy.outputs.url }}
+```
 
 ### Optional inputs
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This GitHub Action encapsulates all of the build and deploy steps required to de
 ```yaml
 - name: Build and Deploy Kubernetes
   uses: dmsi-io/gha-go-deploy@v1.1
-  with: 
+  with:
     GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     GKE_CLUSTER_NAME: ${{ secrets.GCP_STAGING_CLUSTER_NAME }}
     GCP_ZONE: ${{ secrets.GCP_ZONE }}
@@ -34,12 +34,12 @@ Additionally, the Dockerfile must also be located at the head of the repository.
 ### Optional inputs
 
 #### Secret
- 
+
 Used to specify a secret to copy from the default namespace into the namespace being created.
 
 ```yaml
-  with:
-    secret: 'secret-env'
+with:
+  secret: 'secret-env'
 ```
 
 #### Skip Deployment Status
@@ -49,8 +49,8 @@ Sometimes when trying to debug a k8s deployment that refuses to deploy correctly
 - Default: `false`
 
 ```yaml
-  with:
-    skip_deploy_status: true
+with:
+  skip_deploy_status: true
 ```
 
 #### Go Version
@@ -58,8 +58,8 @@ Sometimes when trying to debug a k8s deployment that refuses to deploy correctly
 Older Go services may require a specific version of Go to be able to compile, this can be supplied via the optional input.
 
 ```yaml
-  with:
-    go-version: '^1.13.1' # The Go version to download (if necessary) and use.
+with:
+  go-version: '^1.13.1' # The Go version to download (if necessary) and use.
 ```
 
 #### Skip Dependency Caching
@@ -69,8 +69,8 @@ By default, this GitHub Action will download and save a cache of the dependencie
 - Default: `false`
 
 ```yaml
-  with:
-    skip_cache: true
+with:
+  skip_cache: true
 ```
 
 #### Skip Dependency Install
@@ -80,8 +80,8 @@ By default, this GitHub Action will download and verify dependencies before test
 - Default: `false`
 
 ```yaml
-  with:
-    skip_install: true
+with:
+  skip_install: true
 ```
 
 #### Skip Testing
@@ -91,8 +91,8 @@ By default, this GitHub Action will run all tests before building. This can be s
 - Default: `false`
 
 ```yaml
-  with:
-    skip_testing: true
+with:
+  skip_testing: true
 ```
 
 #### Test Flags
@@ -102,8 +102,8 @@ By default, this GitHub Action will run all tests before building. The following
 - Default: `false`
 
 ```yaml
-  with:
-    test_flags: '-tags mock' # example, can be any available CLI flags
+with:
+  test_flags: '-tags mock' # example, can be any available CLI flags
 ```
 
 #### Build Flags
@@ -113,6 +113,50 @@ The following input field allows additional flags to be added to the CLI `build`
 - Default: `false`
 
 ```yaml
-  with:
-    build_flags: "-a -ldflags '-w'" # example, can be any available CLI flags
+with:
+  build_flags: "-a -ldflags '-w'" # example, can be any available CLI flags
+```
+
+#### Skip Resetting GraphQL Schema
+
+Our middleware is powered by a central graphql-api that will pull all available GraphQL schemas when starting up. Additionally, and endpoint is available to manually reset this schema. By default, this action will ping this endpoint in the new namespace to update the GraphQL schema for the repo in question. Providing a `true` value to this input will turn off this behavior if it unnecessary.
+
+- Default: `false`
+
+```yaml
+with:
+  skip_reset_schema: 'true'
+```
+
+#### Endpoint Ping
+
+Traditionally, to reset the GraphQL schema there is a single endpoint that is predefined. However, if a different Go service would like to ping an alternate endpoint in the created namespace, this optional input provides that ability.
+
+- Default: `/graphql?resetSchema=true`
+
+```yaml
+with:
+  endpoint: '/api/test'
+```
+
+#### Print Environment Variables
+
+Sometimes it is helpful to view the environment variables set to help debug. Supplying this flag will print `env | sort` to the console.
+
+- Default: `false`
+
+```yaml
+with:
+  print_environemnt: 'true'
+```
+
+#### Print GCloud Info
+
+Sometimes it is helpful to view gcloud information to help debug. Supplying this flag will print out `gcloud info` after authenticating.
+
+- Default: `false`
+
+```yaml
+with:
+  print_gcloud_info: 'true'
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -86,6 +86,11 @@ inputs:
     required: false
     default: '/graphql?resetSchema=true'
 
+outputs:
+  url:
+    description: 'URL'
+    value: ${{ steps.deploy.outputs.url }}
+
 runs:
   using: composite
   steps:
@@ -161,6 +166,7 @@ runs:
 
     - name: Deploy Kubernetes
       uses: dmsi-io/gha-k8s-deploy@feature/gha-cleanup
+      id: deploy
       with:
         GCP_SA_KEY: ${{ inputs.GCP_SA_KEY }}
         GKE_CLUSTER_NAME: ${{ inputs.GKE_CLUSTER_NAME }}

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: 'Deploy Go Application to Kubernetes'
 description: 'Used to encapsulate the build and deploy process for Go middleware services.'
 
 inputs:
-  GCP_SA_KEY: 
+  GCP_SA_KEY:
     description: 'GCP Service Account Key (JSON)'
     required: true
 
@@ -10,7 +10,7 @@ inputs:
     description: 'Google Kubernetes Engine Cluster name'
     required: true
 
-  GCP_ZONE: 
+  GCP_ZONE:
     description: 'GCP Zone'
     required: true
 
@@ -22,7 +22,7 @@ inputs:
     description: 'Top Level Domain to create subdomain on.'
     required: true
 
-  GHA_ACCESS_USER: 
+  GHA_ACCESS_USER:
     description: 'GitHub Actions Access Username'
     required: false
 
@@ -125,15 +125,8 @@ runs:
 
     ###### Check and setup Kubernetes configs
 
-    - name: Check k8s folder existence
-      id: k8s_exists
-      uses: andstor/file-existence-action@v1.0.1
-      with:
-        files: "k8s"
-
     - name: Create k8s directory
-      if: steps.k8s_exists.outputs.files_exists != 'true'
-      run: mkdir k8s
+      run: mkdir -p k8s
       shell: bash
 
     - name: Copy missing k8s config files
@@ -144,7 +137,7 @@ runs:
 
     - name: Deploy Kubernetes
       uses: dmsi-io/gha-k8s-deploy@v1
-      with: 
+      with:
         GCP_SA_KEY: ${{ inputs.GCP_SA_KEY }}
         GKE_CLUSTER_NAME: ${{ inputs.GKE_CLUSTER_NAME }}
         GCP_ZONE: ${{ inputs.GCP_ZONE }}

--- a/action.yaml
+++ b/action.yaml
@@ -66,6 +66,16 @@ inputs:
     description: 'Optional flags to supply to the build step'
     required: false
 
+  skip_reset_schema:
+    description: 'Flag to skip GraphQL schema reset call'
+    required: false
+    default: 'false'
+
+  endpoint:
+    description: 'Endpoint to ping with curl during reset schema step'
+    required: false
+    default: '/graphql?resetSchema=true'
+
 runs:
   using: composite
   steps:
@@ -144,3 +154,10 @@ runs:
         GCP_PROJECT_ID: ${{ inputs.GCP_PROJECT_ID }}
         secret: ${{ inputs.secret }}
         skip_deploy_status: ${{ inputs.skip_deploy_status }}
+
+    ###### Reset GraphQL Schema ######
+
+    - name: Reset GraphQL Schema
+      if: inputs.skip_reset_schema != 'true'
+      run: curl "https://$HOSTNAME${{ inputs.endpoint }}"
+      shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -143,6 +143,10 @@ runs:
       run: cp -inv ${{ github.action_path }}/k8s/* k8s
       shell: bash
 
+    - name: Copy default Dockerfile
+      run: cp -inv ${{ github.action_path }}/Dockerfile Dockerfile
+      shell: bash
+
     ###### Deploy Kubernetes ######
 
     - name: Deploy Kubernetes

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,16 @@ inputs:
     description: 'GitHub Actions Access Token'
     required: false
 
+  print_gcloud_info:
+    description: 'Flag to optionally print gcloud info after authenticating'
+    required: false
+    default: 'false'
+
+  print_environemnt:
+    description: 'Flag to optionally print environment variables'
+    required: false
+    default: 'false'
+
   secret:
     description: 'Name of secret to copy from default namespace'
     required: false
@@ -158,6 +168,8 @@ runs:
         GCP_PROJECT_ID: ${{ inputs.GCP_PROJECT_ID }}
         secret: ${{ inputs.secret }}
         skip_deploy_status: ${{ inputs.skip_deploy_status }}
+        print_gcloud_info: ${{ inputs.print_gcloud_info }}
+        print_environemnt: ${{ inputs.print_environemnt }}
 
     ###### Reset GraphQL Schema ######
 

--- a/action.yaml
+++ b/action.yaml
@@ -174,7 +174,7 @@ runs:
     ###### Deploy Kubernetes ######
 
     - name: Deploy Kubernetes
-      uses: dmsi-io/gha-k8s-deploy@feature/gha-cleanup
+      uses: dmsi-io/gha-k8s-deploy@v1.1
       id: deploy
       with:
         GCP_SA_KEY: ${{ inputs.GCP_SA_KEY }}

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,11 @@ inputs:
     required: false
     default: 'false'
 
+  print_go_env:
+    description: 'Flag to optionally print go environment'
+    required: false
+    default: 'false'
+
   secret:
     description: 'Name of secret to copy from default namespace'
     required: false
@@ -115,7 +120,11 @@ runs:
       run: |
         git config --global url."https://${{ inputs.GHA_ACCESS_USER }}:${{ inputs.GHA_ACCESS_TOKEN }}@github.com".insteadOf "https://github.com"
         go env -w GOPRIVATE="github.com/${{ github.repository_owner }}/*"
-        go env
+      shell: bash
+
+    - name: Print Go Environment
+      if: inputs.print_go_env == 'true'
+      run: go env
       shell: bash
 
     - name: Add Dependencies from Cache

--- a/action.yaml
+++ b/action.yaml
@@ -104,7 +104,7 @@ runs:
       shell: bash
 
     - name: Add Dependencies from Cache
-      if: inputs.skip_cache == 'false'
+      if: inputs.skip_cache != 'true'
       uses: actions/cache@v2
       with:
         path: |
@@ -115,14 +115,14 @@ runs:
           ${{ runner.os }}-go-
 
     - name: Install dependencies
-      if: inputs.skip_install == 'false'
+      if: inputs.skip_install != 'true'
       run: |
         go mod download
         go mod verify
       shell: bash
 
     - name: Run unit tests
-      if: inputs.skip_testing == 'false'
+      if: inputs.skip_testing != 'true'
       run: go test ${{ inputs.test_flags }} ./...
       shell: bash
 

--- a/action.yaml
+++ b/action.yaml
@@ -190,5 +190,5 @@ runs:
 
     - name: Reset GraphQL Schema
       if: inputs.skip_reset_schema != 'true'
-      run: curl "https://$HOSTNAME${{ inputs.endpoint }}"
+      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ inputs:
     required: false
     default: 'false'
 
-  print_environemnt:
+  print_environment:
     description: 'Flag to optionally print environment variables'
     required: false
     default: 'false'
@@ -169,7 +169,7 @@ runs:
         secret: ${{ inputs.secret }}
         skip_deploy_status: ${{ inputs.skip_deploy_status }}
         print_gcloud_info: ${{ inputs.print_gcloud_info }}
-        print_environemnt: ${{ inputs.print_environemnt }}
+        print_environment: ${{ inputs.print_environemnt }}
 
     ###### Reset GraphQL Schema ######
 

--- a/action.yaml
+++ b/action.yaml
@@ -160,7 +160,7 @@ runs:
     ###### Deploy Kubernetes ######
 
     - name: Deploy Kubernetes
-      uses: dmsi-io/gha-k8s-deploy@v1
+      uses: dmsi-io/gha-k8s-deploy@feature/gha-cleanup
       with:
         GCP_SA_KEY: ${{ inputs.GCP_SA_KEY }}
         GKE_CLUSTER_NAME: ${{ inputs.GKE_CLUSTER_NAME }}

--- a/action.yaml
+++ b/action.yaml
@@ -175,7 +175,7 @@ runs:
         secret: ${{ inputs.secret }}
         skip_deploy_status: ${{ inputs.skip_deploy_status }}
         print_gcloud_info: ${{ inputs.print_gcloud_info }}
-        print_environment: ${{ inputs.print_environemnt }}
+        print_environment: ${{ inputs.print_environment }}
 
     ###### Reset GraphQL Schema ######
 

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: $SERVICE_NAME
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: http
     port: 80


### PR DESCRIPTION
## 📑 Description
- Added GraphQL reset schema call to end of GHA (can be skipped and endpoint customized)
- Added support to optionally print `env` and `gcloud info` from `gha-k8s-deploy`
- Added input to optionally print `go env`
- Added default Dockerfile (only copied in if acting repo has no Dockerfile)
- Outputs URL of namespace (from `go-k8s-deploy`)
- Changing default K8S Service type: NodePort => ClusterIP

## ✅ Checks
- [x] Waiting on `gha-k8s-deploy` to be [merged](https://github.com/dmsi-io/gha-k8s-deploy/pull/2) and [tagged](https://github.com/dmsi-io/gha-k8s-deploy/releases/tag/v1.1).
- [x] Successful action [run](https://github.com/dmsi-io/door-maint-api/runs/4600590593?check_suite_focus=true): 