### PR TITLE
Add Curl Timeout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -202,5 +202,5 @@ runs:
 
     - name: Reset GraphQL Schema
       if: inputs.skip_reset_schema != 'true' && inputs.skip_k8s_deploy != 'true'
-      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}" --max-time 5
+      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}" --max-time 5 --fail
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -202,5 +202,5 @@ runs:
 
     - name: Reset GraphQL Schema
       if: inputs.skip_reset_schema != 'true' && inputs.skip_k8s_deploy != 'true'
-      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}"
+      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}" --max-time 5
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -202,5 +202,5 @@ runs:
 
     - name: Reset GraphQL Schema
       if: inputs.skip_reset_schema != 'true' && inputs.skip_k8s_deploy != 'true'
-      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}" --max-time 5 --fail
+      run: curl "${{ steps.deploy.outputs.url }}${{ inputs.endpoint }}" --max-time 5 --silent
       shell: bash


### PR DESCRIPTION
## 📑 Description
It was noticed that the reset schema call to graphql-api would sometimes spin for minutes on end, the worst I've seen was 30+ minutes with no answer. 

This changes forces a max request time of 5 seconds and will be silent with errors as to not crash the remaining workflow.

Example run: https://github.com/dmsi-io/users-api/actions/runs/1958258875